### PR TITLE
Allow function to be specified as callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ Events.prototype.bind = function(event, method){
   // callback
   function cb(){
     var a = [].slice.call(arguments).concat(args);
-    obj[method].apply(obj, a);
+    ( typeof method === 'function' ? method : obj[method]).apply(obj, a);
   }
 
   // bind


### PR DESCRIPTION
Backbone events could be written inline.

This is useful for for cases where it doesn't quite make
sense to create a method just for them.  Such as:

```
Backbone.View.extend({
    events:{
       'click button': function(){ this.quack(1) }
     }
    quack: function(number_of_times){

    }

    unrelated_method: function(){
       this.quack(3);
    }
})
```

If the callback was just 'quack', it would be passed the Event object.

It can also be useful for adding events later in the view's lifecycle by calling
this.eventManager.bind() with a function that has closure scope.

My personal use case for it is to setup a listener on the form when it renders:

```
render: function(){
        var special_value = calculateHash();
        AV.prototype.render();
        this.eventManager.bind("change magic.input", _.partial( this._onFieldChange, special_value, _  ) );
        return this;
}
```

I prefer to use the eventManager vs setting up EventListeners on the element, since eventManager handles teardown on remove().
